### PR TITLE
Update to pandas=0.23.0 and distributed=1.16.0

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -28,12 +28,12 @@ let
   inherit (stdenv) isDarwin;
 in buildPythonPackage rec {
   pname = "pandas";
-  version = "0.21.0";
+  version = "0.23.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0nf50ls2cnlsd2635nyji7l70xc91dw81qg5y01g5sifwwqcpmaw";
+    sha256 = "1ncg4hzwi416xlm95fm29p4nn88s3gf69w8i89axkchcb581vaw4";
   };
 
   LC_ALL = "en_US.UTF-8";
@@ -68,7 +68,7 @@ in buildPythonPackage rec {
   checkInputs = [ moto ];
 
   # check phase is flacky and
-  # simply fail withotu sandboxing and large machine ... 
+  # simply fail withotu sandboxing and large machine ...
   doCheck = false;
 
   checkPhase = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4133,11 +4133,11 @@ in {
   distributed = buildPythonPackage rec {
 
     name = "distributed-${version}";
-    version = "1.15.1";
+    version = "1.16.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/d/distributed/${name}.tar.gz";
-      sha256 = "037a07sdf2ch1d360nqwqz3b4ld8msydng7mw4i5s902v7xr05l6";
+      sha256 = "1p6533aphapq2zmv0a1k9x8zrm146vrkjhmmx4jcgj4i7m3159sr";
     };
 
     buildInputs = with self; [ pytest docutils ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

