### PR TITLE
adding cudatoolkit 9.2

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -173,5 +173,12 @@ in {
     gcc = gcc6;
   };
 
+  cudatoolkit92 = common {
+    version = "9.2.148";
+    url = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/local_installers/cuda_9.2.148_396.37_linux";
+    sha256 = "04c6v9b50l4awsf9w9zj5vnxvmc0hk0ypcfjksbh4vnzrz14wigm";
+    gcc = gcc6;
+  };
+
 }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1622,7 +1622,8 @@ with pkgs;
     cudatoolkit7
     cudatoolkit75
     cudatoolkit8
-    cudatoolkit9;
+    cudatoolkit9
+    cudatoolkit92;
 
   cudatoolkit = cudatoolkit9;
 


### PR DESCRIPTION
Adding cudatoolkit 9.2 which supports clang 5.0.0. Needed by Brayns' optix plugin-in